### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1350,7 +1350,7 @@ msgstr "NP-Hartbeton"
 #: data/mp/messages/strings/names.txt:395
 #: po/custom/fromJson.txt:587
 msgid "Heavy Machinegun Bunker"
-msgstr "Bunker mit schwerem Maschinengewehr"
+msgstr "Bunker mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/names.txt:316
 #: data/mp/messages/strings/names.txt:397
@@ -1361,7 +1361,7 @@ msgstr "Stellung mit Flashlight"
 #: data/base/messages/strings/names.txt:322
 #: po/custom/fromJson.txt:592
 msgid "Heavy Machinegun Guard Tower"
-msgstr "Wachturm mit schwerem Maschinengewehr"
+msgstr "Wachturm mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/names.txt:323
 #: po/custom/fromJson.txt:479
@@ -2075,7 +2075,7 @@ msgstr "Verstärkter Turm mit Sturmgewehr"
 #: data/base/messages/strings/resstrings.txt:234
 #: data/mp/messages/strings/resstrings.txt:117
 msgid "Armored guard tower with Heavy Machinegun"
-msgstr "Gepanzerter Wachturm mit schwerem Maschinengewehr"
+msgstr "Gepanzerter Wachturm mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/resstrings.txt:235
 #: data/base/messages/strings/resstrings.txt:241
@@ -2112,7 +2112,7 @@ msgstr "Gepanzerter Wachturm mit Lancer-Antipanzerrakete"
 #: data/base/messages/strings/resstrings.txt:260
 #: data/mp/messages/strings/resstrings.txt:132
 msgid "Armored bunker with Heavy Machinegun"
-msgstr "Gepanzerter Bunker mit schwerem Maschinengewehr"
+msgstr "Gepanzerter Bunker mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/resstrings.txt:280
 #: data/mp/messages/strings/resstrings.txt:137
@@ -2901,7 +2901,7 @@ msgstr "Beste Ziele: Fahrzeuge"
 #: data/mp/messages/strings/resstrings.txt:354
 #: po/custom/fromJson.txt:1125
 msgid "Replaces Medium Cannon"
-msgstr "Ersetzt mittleres Kanone"
+msgstr "Ersetzt Mittlere Kanone"
 
 #: data/base/messages/strings/resstrings.txt:736
 #: data/mp/messages/strings/resstrings.txt:357
@@ -4434,7 +4434,7 @@ msgstr "Cyborg-Antrieb"
 #: data/mp/messages/strings/names.txt:404
 #: po/custom/fromJson.txt:596
 msgid "Heavy Machinegun Tower"
-msgstr "Turm mit schwerem Maschinengewehr"
+msgstr "Turm mit Schwerem Maschinengewehr"
 
 #: data/mp/messages/strings/names.txt:405
 msgid "Flamer Tower"
@@ -5138,7 +5138,7 @@ msgstr "Gepanzerter Bunker mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:145
 msgid "Armored bunker with Light Cannon"
-msgstr "Gepanzerter Bunker mit leichter Kanone"
+msgstr "Gepanzerter Bunker mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:146
 msgid "Armored bunker with Machinegun"
@@ -5194,11 +5194,11 @@ msgstr "Gepanzerte Aufhängung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:162
 msgid "Armored hardpoint with Heavy Cannon"
-msgstr "Gepanzerte Aufhängung mit schwerer Kanone"
+msgstr "Gepanzerte Aufhängung mit Schwerer Kanone"
 
 #: po/custom/fromJson.txt:163
 msgid "Armored hardpoint with Heavy Machinegun"
-msgstr "Gepanzerte Aufhängung mit schwerem Maschinengewehr"
+msgstr "Gepanzerte Aufhängung mit Schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:164
 msgid "Armored hardpoint with Hyper-Velocity Cannon"
@@ -5210,7 +5210,7 @@ msgstr "Gepanzerte Aufhängung mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:167
 msgid "Armored hardpoint with Light Cannon"
-msgstr "Gepanzerte Aufhängung mit leichter Kanone"
+msgstr "Gepanzerte Aufhängung mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:168
 msgid "Armored hardpoint with Medium Cannon"
@@ -5242,7 +5242,7 @@ msgstr "Gepanzerte Stellung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:180
 msgid "Armored strongpoint with Heavy Laser"
-msgstr "Gepanzerte Stellung mit schwerem Laser"
+msgstr "Gepanzerte Stellung mit Schwerem Laser"
 
 #: po/custom/fromJson.txt:183
 msgid "Armored strongpoint with Plasmite Flamer"
@@ -5717,7 +5717,7 @@ msgstr "Cobra Flammenwerfer Ketten"
 
 #: po/custom/fromJson.txt:323
 msgid "Cobra Medium Cannon Tracks"
-msgstr "Cobra Mittleres Kanone Ketten"
+msgstr "Cobra Mittlere Kanone Ketten"
 
 #: po/custom/fromJson.txt:324
 msgid "Cobra Truck"
@@ -6591,7 +6591,7 @@ msgstr "Schwere Kanone mit 120-mm-Geschossen"
 
 #: po/custom/fromJson.txt:571
 msgid "Heavy Cannon Hardpoint"
-msgstr "Aufhängung mit schwerer Kanone"
+msgstr "Aufhängung mit Schwerer Kanone"
 
 #: po/custom/fromJson.txt:572
 msgid "Heavy Cannon Mantis Tracks"
@@ -6631,7 +6631,7 @@ msgstr "Schwerer Laser"
 
 #: po/custom/fromJson.txt:583
 msgid "Heavy Laser Emplacement"
-msgstr "Stellung mit schweren Laser"
+msgstr "Stellung mit Schwerem Laser"
 
 #: po/custom/fromJson.txt:584
 msgid "Heavy Laser Tiger Tracks"
@@ -6663,7 +6663,7 @@ msgstr "Schweres Maschinengewehr Cobra Räder"
 
 #: po/custom/fromJson.txt:593
 msgid "Heavy Machinegun Hardpoint"
-msgstr "Aufhängung mit schwerem Maschinengewehr"
+msgstr "Aufhängung mit Schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:594
 msgid "Heavy Machinegun Scorpion Half Tracks"
@@ -7416,7 +7416,7 @@ msgstr "Leichte Kanone"
 
 #: po/custom/fromJson.txt:828
 msgid "Light Cannon Bunker"
-msgstr "Bunker mit leichter Kanone"
+msgstr "Bunker mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:829
 msgid "Light Cannon Cobra Tracks"
@@ -7428,7 +7428,7 @@ msgstr "Leichte Kanone mit 40-mm-Geschossen"
 
 #: po/custom/fromJson.txt:831
 msgid "Light Cannon Hardpoint"
-msgstr "Aufhängung mit leichter Kanone"
+msgstr "Aufhängung mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:832
 msgid "Light Cannon Python Tracks"

--- a/po/de.po
+++ b/po/de.po
@@ -1203,7 +1203,7 @@ msgstr "Neuer Entwurf"
 #: data/base/messages/strings/names.txt:103
 #: data/mp/messages/strings/names.txt:160
 msgid "Cyborg Cannon"
-msgstr "Cyborggeschütz"
+msgstr "Cyborgkanone"
 
 #: data/base/messages/strings/names.txt:149
 #: data/base/messages/strings/names.txt:182
@@ -2030,7 +2030,7 @@ msgstr "Greift automatisch Ziele in Reichweite an"
 #: data/mp/messages/strings/resstrings.txt:97
 #: po/custom/fromJson.txt:181
 msgid "Armored strongpoint with Hyper-Velocity Cannon"
-msgstr "Gepanzerte Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Gepanzerte Stellung mit Hochgeschwindigkeitskanone"
 
 #: data/base/messages/strings/resstrings.txt:200
 #: data/base/messages/strings/resstrings.txt:220
@@ -2064,7 +2064,7 @@ msgstr "Gepanzerte Stellung mit Inferno-Flammenwerfer"
 #: data/mp/messages/strings/resstrings.txt:107
 #: po/custom/fromJson.txt:177
 msgid "Armored strongpoint with Assault Cannon"
-msgstr "Gepanzerte Stellung mit Sturmgeschütz"
+msgstr "Gepanzerte Stellung mit Sturmkanone"
 
 #: data/base/messages/strings/resstrings.txt:224
 #: data/mp/messages/strings/resstrings.txt:112
@@ -2129,7 +2129,7 @@ msgstr "Gepanzerte Aufhängung mit Sturmgewehr"
 #: data/mp/messages/strings/resstrings.txt:147
 #: po/custom/fromJson.txt:158
 msgid "Armored hardpoint with Assault Cannon"
-msgstr "Gepanzerte Aufhängung mit Sturmgeschütz"
+msgstr "Gepanzerte Aufhängung mit Sturmkanone"
 
 #: data/base/messages/strings/resstrings.txt:302
 #: data/mp/messages/strings/resstrings.txt:152
@@ -2887,7 +2887,7 @@ msgstr "Neuer Waffenturm verfügbar"
 #: data/mp/messages/strings/resstrings.txt:352
 #: po/custom/fromJson.txt:684
 msgid "Hyper-velocity automatic-cannon firing 88mm rounds"
-msgstr "Hochgeschwindigkeitsautomatikgeschütz mit 88-mm-Geschossen"
+msgstr "Hochgeschwindigkeitsautomatikkanone mit 88-mm-Geschossen"
 
 #: data/base/messages/strings/resstrings.txt:731
 #: data/base/messages/strings/resstrings.txt:737
@@ -2901,13 +2901,13 @@ msgstr "Beste Ziele: Fahrzeuge"
 #: data/mp/messages/strings/resstrings.txt:354
 #: po/custom/fromJson.txt:1125
 msgid "Replaces Medium Cannon"
-msgstr "Ersetzt mittleres Geschütz"
+msgstr "Ersetzt mittleres Kanone"
 
 #: data/base/messages/strings/resstrings.txt:736
 #: data/mp/messages/strings/resstrings.txt:357
 #: po/custom/fromJson.txt:8
 msgid "76mm hyper-velocity quad-barrel automatic-cannon"
-msgstr "Vierläufiges 76-mm-Hochgeschwindigkeitsautomatikgeschütz"
+msgstr "Vierläufige 76-mm-Hochgeschwindigkeitsautomatikkanone"
 
 #: data/base/messages/strings/resstrings.txt:738
 #: data/mp/messages/strings/resstrings.txt:359
@@ -4542,12 +4542,12 @@ msgstr "Schwerer Superschütze"
 #: data/mp/messages/strings/names.txt:777
 #: po/custom/fromJson.txt:1252
 msgid "Super Auto-Cannon Cyborg"
-msgstr "Sturmgeschütz-Supercyborg"
+msgstr "Sturmkanone-Supercyborg"
 
 #: data/mp/messages/strings/names.txt:779
 #: po/custom/fromJson.txt:1268
 msgid "Super HPV Cyborg"
-msgstr "Hochgeschwindigkeitsgeschütz-Supercyborg"
+msgstr "Hochgeschwindigkeitskanone-Supercyborg"
 
 #: data/mp/messages/strings/names.txt:781
 #: po/custom/fromJson.txt:1274
@@ -4745,7 +4745,7 @@ msgstr "7,62-mm-Maschinengewehr"
 
 #: po/custom/fromJson.txt:9
 msgid "76mm twin-barrel automatic-cannon"
-msgstr "Doppelläufiges 76-mm-Schnellfeuergeschütz"
+msgstr "Doppelläufige 76-mm-Schnellfeuerkanone"
 
 #: po/custom/fromJson.txt:10
 msgid "AA accuracy +10%"
@@ -4938,7 +4938,7 @@ msgstr "Aerodynamiklabor"
 
 #: po/custom/fromJson.txt:70
 msgid "All cannons upgraded automatically"
-msgstr "Alle Geschütze wurden automatisch aufgerüstet"
+msgstr "Alle Kanonen wurden automatisch aufgerüstet"
 
 #: po/custom/fromJson.txt:71
 msgid "All CB sensors upgraded automatically"
@@ -5026,15 +5026,15 @@ msgstr "Panzerbrechende Treibspiegelprojektile für Maschinengewehre Mk3"
 
 #: po/custom/fromJson.txt:113
 msgid "APFSDS Cannon Rounds"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:114
 msgid "APFSDS Cannon Rounds Mk2"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze Mk2"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:115
 msgid "APFSDS Cannon Rounds Mk3"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze Mk3"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:116
 msgid "Archangel Missile"
@@ -5054,7 +5054,7 @@ msgstr "Bewaffnet mit Cyborgsturmgewehr"
 
 #: po/custom/fromJson.txt:122
 msgid "Armed with Cyborg Cannon"
-msgstr "Bewaffnet mit Cyborggeschütz"
+msgstr "Bewaffnet mit Cyborgkanone"
 
 #: po/custom/fromJson.txt:123
 msgid "Armed with Cyborg Flamer"
@@ -5070,7 +5070,7 @@ msgstr "Bewaffnet mit Pulslaser für Cyborgs"
 
 #: po/custom/fromJson.txt:126
 msgid "Armed with Cyborg Rail Gun"
-msgstr "Bewaffnet mit Magnetgeschütz für Cyborgs"
+msgstr "Bewaffnet mit Magnetkanone für Cyborgs"
 
 #: po/custom/fromJson.txt:127
 msgid "Armed with Cyborg Scourge Missile Launcher"
@@ -5094,7 +5094,7 @@ msgstr "Bewaffnet mit Mörsergranaten"
 
 #: po/custom/fromJson.txt:132
 msgid "Armed with hyper velocity cannon"
-msgstr "Bewaffnet mit Hochgeschwindigkeitsgeschütz"
+msgstr "Bewaffnet mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:133
 msgid "Armed with Lance Anti-Tank rocket"
@@ -5110,11 +5110,11 @@ msgstr "Bewaffnet mit einem Maschinengewehr"
 
 #: po/custom/fromJson.txt:136
 msgid "Armed with medium cannon"
-msgstr "Bewaffnet mit mittlerem Geschütz"
+msgstr "Bewaffnet mit mittlerer Kanone"
 
 #: po/custom/fromJson.txt:137
 msgid "Armed with Needle Gun"
-msgstr "Bewaffnet mit Nadelgeschütz"
+msgstr "Bewaffnet mit Nadelkanone"
 
 #: po/custom/fromJson.txt:139
 msgid "Armed with Scourge anti-tank missile"
@@ -5138,7 +5138,7 @@ msgstr "Gepanzerter Bunker mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:145
 msgid "Armored bunker with Light Cannon"
-msgstr "Gepanzerter Bunker mit leichtem Geschütz"
+msgstr "Gepanzerter Bunker mit leichter Kanone"
 
 #: po/custom/fromJson.txt:146
 msgid "Armored bunker with Machinegun"
@@ -5150,7 +5150,7 @@ msgstr "Gepanzerte Grube mit EMP-Mörser"
 
 #: po/custom/fromJson.txt:149
 msgid "Armored guard tower with EMP Cannon"
-msgstr "Gepanzerter Wachturm mit EMP-Geschütz"
+msgstr "Gepanzerter Wachturm mit EMP-Kanone"
 
 #: po/custom/fromJson.txt:150
 msgid "Armored guard tower with Lancer AT rocket"
@@ -5166,7 +5166,7 @@ msgstr "Gepanzerter Wachturm mit Miniraketenhalter"
 
 #: po/custom/fromJson.txt:153
 msgid "Armored guard tower with Needle Gun"
-msgstr "Gepanzerter Wachturm mit Nadelgeschütz"
+msgstr "Gepanzerter Wachturm mit Nadelkanone"
 
 #: po/custom/fromJson.txt:154
 msgid "Armored guard tower with Nexus Link"
@@ -5194,7 +5194,7 @@ msgstr "Gepanzerte Aufhängung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:162
 msgid "Armored hardpoint with Heavy Cannon"
-msgstr "Gepanzerte Aufhängung mit schwerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit schwerer Kanone"
 
 #: po/custom/fromJson.txt:163
 msgid "Armored hardpoint with Heavy Machinegun"
@@ -5202,7 +5202,7 @@ msgstr "Gepanzerte Aufhängung mit schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:164
 msgid "Armored hardpoint with Hyper-Velocity Cannon"
-msgstr "Gepanzerte Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Gepanzerte Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:166
 msgid "Armored hardpoint with Lancer AT missile"
@@ -5210,15 +5210,15 @@ msgstr "Gepanzerte Aufhängung mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:167
 msgid "Armored hardpoint with Light Cannon"
-msgstr "Gepanzerte Aufhängung mit leichtem Geschütz"
+msgstr "Gepanzerte Aufhängung mit leichter Kanone"
 
 #: po/custom/fromJson.txt:168
 msgid "Armored hardpoint with Medium Cannon"
-msgstr "Gepanzerte Aufhängung mit mittlerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit mittlerer Kanone"
 
 #: po/custom/fromJson.txt:169
 msgid "Armored hardpoint with Rail Gun"
-msgstr "Gepanzerte Aufhängung mit Magnetgeschütz"
+msgstr "Gepanzerte Aufhängung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:170
 msgid "Armored hardpoint with Scourge AT Missile"
@@ -5254,7 +5254,7 @@ msgstr "Gepanzerte Stellung mit Pulslaser"
 
 #: po/custom/fromJson.txt:185
 msgid "Armored strongpoint with Rail Gun"
-msgstr "Gepanzerte Stellung mit Magnetgeschütz"
+msgstr "Gepanzerte Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:187
 msgid "Armored Tracks"
@@ -5286,23 +5286,23 @@ msgstr "Artilleriebatterie verschießt Novastorm-Lenkraketen"
 
 #: po/custom/fromJson.txt:194
 msgid "Assault Cannon"
-msgstr "Sturmgeschütz"
+msgstr "Sturmkanone"
 
 #: po/custom/fromJson.txt:195
 msgid "Assault Cannon Emplacement"
-msgstr "Stellung mit Sturmgeschütz"
+msgstr "Stellung mit Sturmkanone"
 
 #: po/custom/fromJson.txt:196
 msgid "Assault Cannon Guard Tower"
-msgstr "Wachturm mit Sturmgeschütz"
+msgstr "Wachturm mit Sturmkanone"
 
 #: po/custom/fromJson.txt:197
 msgid "Assault Cannon Hardpoint"
-msgstr "Aufhängung mit Sturmgeschütz"
+msgstr "Aufhängung mit Sturmkanone"
 
 #: po/custom/fromJson.txt:198
 msgid "Assault Cannon Mantis Hover"
-msgstr "Sturmgeschütz Mantis Hover"
+msgstr "Sturmkanone Mantis Hover"
 
 #: po/custom/fromJson.txt:199
 msgid "Assault Gun"
@@ -5606,66 +5606,66 @@ msgstr "Verbrennt Öl effizienter"
 
 #: po/custom/fromJson.txt:296
 msgid "Cannon accuracy +10%"
-msgstr "Geschützgenauigkeit +10%"
+msgstr "Kanonengenauigkeit +10%"
 
 # auto -> selbst
 # Substantiv im Englischen absichtlich als Adjektiv im Deutschen -Kreuvf
 #: po/custom/fromJson.txt:297
 msgid "Cannon Autoloader"
-msgstr "Selbstladende Geschütze"
+msgstr "Selbstladende Kanonen"
 
 #: po/custom/fromJson.txt:298
 msgid "Cannon Autoloader Mk2"
-msgstr "Selbstladende Geschütze Mk2"
+msgstr "Selbstladende Kanonen Mk2"
 
 #: po/custom/fromJson.txt:299
 msgid "Cannon Autoloader Mk3"
-msgstr "Selbstladende Geschütze Mk3"
+msgstr "Selbstladende Kanonen Mk3"
 
 #: po/custom/fromJson.txt:300
 msgid "Cannon damage +25%"
-msgstr "Geschützschaden +25%"
+msgstr "Kanonenschaden +25%"
 
 #: po/custom/fromJson.txt:301
 msgid "Cannon Fire Truck"
-msgstr "Feuerwehrfahrzeug mit Geschütz"
+msgstr "Feuerwehrfahrzeug mit Kanone"
 
 #: po/custom/fromJson.txt:302
 msgid "Cannon Fortress"
-msgstr "Geschützfestung"
+msgstr "Kanonenfestung"
 
 #: po/custom/fromJson.txt:303
 msgid "Cannon Laser Designator"
-msgstr "Laserzielgeber für Geschütze"
+msgstr "Laserzielgeber für Kanonen"
 
 #: po/custom/fromJson.txt:304
 msgid "Cannon Laser Rangefinder"
-msgstr "Laserentfernungsmesser für Geschütze"
+msgstr "Laserentfernungsmesser für Kanonen"
 
 # Substantiv im Englischen absichtlich adjektivisch im Deutschen -Kreuvf
 #: po/custom/fromJson.txt:305
 msgid "Cannon Rapid Loader"
-msgstr "Schnell ladende Geschütze"
+msgstr "Schnell ladende Kanonen"
 
 #: po/custom/fromJson.txt:306
 msgid "Cannon Rapid Loader Mk2"
-msgstr "Schnell ladende Geschütze Mk2"
+msgstr "Schnell ladende Kanonen Mk2"
 
 #: po/custom/fromJson.txt:307
 msgid "Cannon Rapid Loader Mk3"
-msgstr "Schnell ladende Geschütze Mk3"
+msgstr "Schnell ladende Kanonen Mk3"
 
 #: po/custom/fromJson.txt:308
 msgid "Cannon reload time -10%"
-msgstr "Geschütznachladezeit -10%"
+msgstr "Kanonennachladezeit -10%"
 
 #: po/custom/fromJson.txt:309
 msgid "Cannon Tower"
-msgstr "Geschützturm"
+msgstr "Kanonenturm"
 
 #: po/custom/fromJson.txt:310
 msgid "Cannon Upgrade"
-msgstr "Geschützverbesserung"
+msgstr "Kanonenverbesserung"
 
 #: po/custom/fromJson.txt:311
 msgid "CB Radar Turret"
@@ -5717,7 +5717,7 @@ msgstr "Cobra Flammenwerfer Ketten"
 
 #: po/custom/fromJson.txt:323
 msgid "Cobra Medium Cannon Tracks"
-msgstr "Cobra Mittleres Geschütz Ketten"
+msgstr "Cobra Mittleres Kanone Ketten"
 
 #: po/custom/fromJson.txt:324
 msgid "Cobra Truck"
@@ -6065,11 +6065,11 @@ msgstr "Greift feindliche Gebäude an und stört diese elektronisch"
 
 #: po/custom/fromJson.txt:428
 msgid "EMP Cannon"
-msgstr "EMP-Geschütz"
+msgstr "EMP-Kanone"
 
 #: po/custom/fromJson.txt:429
 msgid "EMP Cannon Tower"
-msgstr "Turm mit EMP-Geschütz"
+msgstr "Turm mit EMP-Kanone"
 
 #: po/custom/fromJson.txt:430
 msgid "EMP Missile Launcher"
@@ -6523,15 +6523,15 @@ msgstr "Hochexplosive panzerbrechende Mörsergranaten Mk3"
 
 #: po/custom/fromJson.txt:552
 msgid "HEAT Cannon Shells"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:553
 msgid "HEAT Cannon Shells Mk2"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze Mk2"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:554
 msgid "HEAT Cannon Shells Mk3"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze Mk3"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:557
 msgid "HEAT Rocket Warhead"
@@ -6575,43 +6575,43 @@ msgstr "Schwerer Rumpf - Wyvern"
 
 #: po/custom/fromJson.txt:567
 msgid "Heavy Cannon"
-msgstr "Schweres Geschütz"
+msgstr "Schwere Kanone"
 
 #: po/custom/fromJson.txt:568
 msgid "Heavy Cannon Cobra Hover"
-msgstr "Schweres Geschütz Cobra Hover"
+msgstr "Schwere Kanone Cobra Hover"
 
 #: po/custom/fromJson.txt:569
 msgid "Heavy Cannon Cobra Tracks"
-msgstr "Schweres Geschütz Cobra Ketten"
+msgstr "Schwere Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:570
 msgid "Heavy Cannon firing 120 mm rounds"
-msgstr "Schweres Geschütz mit 120-mm-Geschossen"
+msgstr "Schwere Kanone mit 120-mm-Geschossen"
 
 #: po/custom/fromJson.txt:571
 msgid "Heavy Cannon Hardpoint"
-msgstr "Aufhängung mit schwerem Geschütz"
+msgstr "Aufhängung mit schwerer Kanone"
 
 #: po/custom/fromJson.txt:572
 msgid "Heavy Cannon Mantis Tracks"
-msgstr "Schweres Geschütz Mantis Ketten"
+msgstr "Schwere Kanone Mantis Ketten"
 
 #: po/custom/fromJson.txt:573
 msgid "Heavy Cannon Python Hover"
-msgstr "Schweres Geschütz Python Hover"
+msgstr "Schwere Kanone Python Hover"
 
 #: po/custom/fromJson.txt:574
 msgid "Heavy Cannon Python Tracks"
-msgstr "Schweres Geschütz Python Ketten"
+msgstr "Schwere Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:575
 msgid "Heavy Cannon Scorpion Tracks"
-msgstr "Schweres Geschütz Scorpion Ketten"
+msgstr "Schwere Kanone Scorpion Ketten"
 
 #: po/custom/fromJson.txt:576
 msgid "Heavy Cannon Tiger Tracks"
-msgstr "Schweres Geschütz Tiger Ketten"
+msgstr "Schwere Kanone Tiger Ketten"
 
 #: po/custom/fromJson.txt:577
 msgid "Heavy Flamer - Inferno"
@@ -6808,7 +6808,7 @@ msgstr "Hochverdichtete Materialien für Basisgebäude"
 
 #: po/custom/fromJson.txt:633
 msgid "High Explosive Anti-Tank Cannon Shells"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:634
 msgid "High Explosive Anti-Tank warhead"
@@ -6928,15 +6928,15 @@ msgstr "Haubitzennachladezeit -10%"
 
 #: po/custom/fromJson.txt:674
 msgid "HPV Cannon Emplacement"
-msgstr "Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Stellung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:675
 msgid "HPV Cannon Hardpoint"
-msgstr "Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:676
 msgid "HPV Cannon Python Tracks"
-msgstr "Hochgeschwindigkeitsgeschütz Python Ketten"
+msgstr "Hochgeschwindigkeitskanone Python Ketten"
 
 #: po/custom/fromJson.txt:677
 msgid "Hurricane AA Site"
@@ -6952,15 +6952,15 @@ msgstr "Hütte"
 
 #: po/custom/fromJson.txt:680
 msgid "HVAPFSDS Cannon Rounds"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:681
 msgid "HVAPFSDS Cannon Rounds Mk2"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze Mk2"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:682
 msgid "HVAPFSDS Cannon Rounds Mk3"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze Mk3"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:683
 msgid "Hyper Fire Chaingun Upgrade"
@@ -6968,23 +6968,23 @@ msgstr "Hyperschnellfeuermechanismus für Maschinengewehre"
 
 #: po/custom/fromJson.txt:685
 msgid "Hyper Velocity Cannon"
-msgstr "Hochgeschwindigkeitsgeschütz"
+msgstr "Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:686
 msgid "Hyper Velocity Cannon Emplacement"
-msgstr "Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Stellung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:687
 msgid "Hyper Velocity Cannon Hardpoint"
-msgstr "Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:688
 msgid "Hyper Velocity Cannon Python Hover"
-msgstr "Hochgeschwindigkeitsgeschütz Python Hover"
+msgstr "Hochgeschwindigkeitskanone Python Hover"
 
 #: po/custom/fromJson.txt:689
 msgid "Hyper Velocity Cannon Python Tracks"
-msgstr "Hochgeschwindigkeitsgeschütz Python Ketten"
+msgstr "Hochgeschwindigkeitskanone Python Ketten"
 
 #: po/custom/fromJson.txt:690
 msgid "Immense damage infliction capability"
@@ -7112,15 +7112,15 @@ msgstr "Erhöht Panzerung und Rumpfpunkte"
 
 #: po/custom/fromJson.txt:730
 msgid "Increases Cannon accuracy"
-msgstr "Erhöht Genauigkeit von Geschützen"
+msgstr "Erhöht Genauigkeit von Kanonen"
 
 #: po/custom/fromJson.txt:731
 msgid "Increases Cannon damage"
-msgstr "Erhöht Schaden von Geschützen"
+msgstr "Erhöht Schaden von Kanonen"
 
 #: po/custom/fromJson.txt:732
 msgid "Increases Cannon ROF"
-msgstr "Erhöht Feuerrate von Geschützen"
+msgstr "Erhöht Feuerrate von Kanonen"
 
 #: po/custom/fromJson.txt:733
 msgid "Increases construction speed"
@@ -7412,39 +7412,39 @@ msgstr "Anfällig gegen schwere Waffen"
 
 #: po/custom/fromJson.txt:827
 msgid "Light Cannon"
-msgstr "Leichtes Geschütz"
+msgstr "Leichte Kanone"
 
 #: po/custom/fromJson.txt:828
 msgid "Light Cannon Bunker"
-msgstr "Bunker mit leichtem Geschütz"
+msgstr "Bunker mit leichter Kanone"
 
 #: po/custom/fromJson.txt:829
 msgid "Light Cannon Cobra Tracks"
-msgstr "Leichtes Geschütz Cobra Ketten"
+msgstr "Leichte Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:830
 msgid "Light Cannon firing 40mm rounds"
-msgstr "Leichtes Geschütz mit 40-mm-Geschossen"
+msgstr "Leichte Kanone mit 40-mm-Geschossen"
 
 #: po/custom/fromJson.txt:831
 msgid "Light Cannon Hardpoint"
-msgstr "Aufhängung mit leichtem Geschütz"
+msgstr "Aufhängung mit leichter Kanone"
 
 #: po/custom/fromJson.txt:832
 msgid "Light Cannon Python Tracks"
-msgstr "Leichtes Geschütz Python Ketten"
+msgstr "Leichte Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:833
 msgid "Light Cannon Viper Half-tracks"
-msgstr "Leichtes Geschütz Viper Halbketten"
+msgstr "Leichte Kanone Viper Halbketten"
 
 #: po/custom/fromJson.txt:834
 msgid "Light Cannon Viper Tracks"
-msgstr "Leichtes Geschütz Viper Ketten"
+msgstr "Leichte Kanone Viper Ketten"
 
 #: po/custom/fromJson.txt:835
 msgid "Light Cannon Viper Wheels"
-msgstr "Leichtes Geschütz Viper Räder"
+msgstr "Leichte Kanone Viper Räder"
 
 #: po/custom/fromJson.txt:837
 msgid "Look-Out Tower"
@@ -7540,47 +7540,47 @@ msgstr "Mittlerer Rumpf - Scorpion"
 
 #: po/custom/fromJson.txt:867
 msgid "Medium Cannon"
-msgstr "Mittleres Geschütz"
+msgstr "Mittlere Kanone"
 
 #: po/custom/fromJson.txt:868
 msgid "Medium Cannon Cobra Half Track"
-msgstr "Mittleres Geschütz Cobra Halbketten"
+msgstr "Mittlere Kanone Cobra Halbketten"
 
 #: po/custom/fromJson.txt:869
 msgid "Medium Cannon Cobra Hover"
-msgstr "Mittleres Geschütz Cobra Hover"
+msgstr "Mittlere Kanone Cobra Hover"
 
 #: po/custom/fromJson.txt:870
 msgid "Medium Cannon Cobra Tracks"
-msgstr "Mittleres Geschütz Cobra Ketten"
+msgstr "Mittlere Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:871
 msgid "Medium Cannon firing 76mm rounds"
-msgstr "Mittleres Geschütz mit 76-mm-Geschossen"
+msgstr "Mittlere Kanone mit 76-mm-Geschossen"
 
 #: po/custom/fromJson.txt:872
 msgid "Medium Cannon Hardpoint"
-msgstr "Aufhängung mit mittlerem Geschütz"
+msgstr "Aufhängung mit mittlerer Kanone"
 
 #: po/custom/fromJson.txt:873
 msgid "Medium Cannon Python Hover"
-msgstr "Mittleres Geschütz Python Hover"
+msgstr "Mittlere Kanone Python Hover"
 
 #: po/custom/fromJson.txt:874
 msgid "Medium Cannon Python Tracks"
-msgstr "Mittleres Geschütz Python Ketten"
+msgstr "Mittlere Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:875
 msgid "Medium Cannon Scorpion Hover"
-msgstr "Mittleres Geschütz Scorpion Hover"
+msgstr "Mittlere Kanone Scorpion Hover"
 
 #: po/custom/fromJson.txt:876
 msgid "Medium Cannon Scorpion Tracks"
-msgstr "Mittleres Geschütz Scorpion Ketten"
+msgstr "Mittlere Kanone Scorpion Ketten"
 
 #: po/custom/fromJson.txt:877
 msgid "Medium Cannon Viper Tracks"
-msgstr "Mittleres Geschütz Viper Ketten"
+msgstr "Mittlere Kanone Viper Ketten"
 
 #: po/custom/fromJson.txt:878
 msgid "Medium Super Heavy Body"
@@ -7760,7 +7760,7 @@ msgstr "Geringer Wirkungsradius"
 
 #: po/custom/fromJson.txt:927
 msgid "Needle Gun"
-msgstr "Nadelgeschütz"
+msgstr "Nadelkanone"
 
 #: po/custom/fromJson.txt:928
 msgid "Needle Gunner"
@@ -7772,19 +7772,19 @@ msgstr "Nadelschütze"
 
 #: po/custom/fromJson.txt:930
 msgid "Needle Gun Retribution Tracks"
-msgstr "Nadelgeschütz Retribution Ketten"
+msgstr "Nadelkanone Retribution Ketten"
 
 #: po/custom/fromJson.txt:931
 msgid "Needle Gun Tiger Tracks"
-msgstr "Nadelgeschütz Tiger Ketten"
+msgstr "Nadelkanone Tiger Ketten"
 
 #: po/custom/fromJson.txt:932
 msgid "Needle Gun Tower"
-msgstr "Turm mit Nadelgeschütz"
+msgstr "Turm mit Nadelkanone"
 
 #: po/custom/fromJson.txt:933
 msgid "Needle Gun Vengeance Tracks"
-msgstr "Nadelgeschütz Vengeance Ketten"
+msgstr "Nadelkanone Vengeance Ketten"
 
 # Wenn man Brain als KI-gestütztes Forschungsorgan betrachtet, könnte die Übersetzung hinhauen -Kreuvf
 #: po/custom/fromJson.txt:934
@@ -8277,7 +8277,7 @@ msgstr "Python"
 
 #: po/custom/fromJson.txt:1075
 msgid "Python Heavy Cannon Tracks"
-msgstr "Python Schweres Geschütz Ketten"
+msgstr "Python Schwere Kanone Ketten"
 
 #: po/custom/fromJson.txt:1077
 msgid "Quad 80mm Anti-Aircraft machinegun"
@@ -8301,7 +8301,7 @@ msgstr "Radardetektorturm"
 
 #: po/custom/fromJson.txt:1083
 msgid "Rail Gun"
-msgstr "Magnetgeschütz"
+msgstr "Magnetkanone"
 
 #: po/custom/fromJson.txt:1084
 msgid "Rail Gun accuracy +10%"
@@ -8313,11 +8313,11 @@ msgstr "Magnetwaffenschaden +25%"
 
 #: po/custom/fromJson.txt:1086
 msgid "Railgun Emplacement"
-msgstr "Stellung mit Magnetgeschütz"
+msgstr "Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1087
 msgid "Rail Gun Emplacement"
-msgstr "Stellung mit Magnetgeschütz"
+msgstr "Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1088
 msgid "Rail gun firing armor-piercing darts"
@@ -8325,11 +8325,11 @@ msgstr "Magnetwaffe verschießt panzerbrechende Pfeile"
 
 #: po/custom/fromJson.txt:1089
 msgid "Rail Gun Hardpoint"
-msgstr "Aufhängung mit Magnetgeschütz"
+msgstr "Aufhängung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1090
 msgid "Rail Gun Mantis Tracks"
-msgstr "Magnetgeschütz Mantis Ketten"
+msgstr "Magnetkanone Mantis Ketten"
 
 #: po/custom/fromJson.txt:1091
 msgid "Rail Gun reload time -15%"
@@ -8349,7 +8349,7 @@ msgstr "Verbesserte Feuerrate von Magnetwaffen Mk3"
 
 #: po/custom/fromJson.txt:1095
 msgid "Rail Gun Tiger Hover"
-msgstr "Magnetgeschütz Tiger Hover"
+msgstr "Magnetkanone Tiger Hover"
 
 #: po/custom/fromJson.txt:1096
 msgid "Rail Gun Upgrade"
@@ -9232,11 +9232,11 @@ msgstr "7,62-mm-Zwillingsmaschinengewehr"
 
 #: po/custom/fromJson.txt:1348
 msgid "Twin Assault Cannon"
-msgstr "Zwillingssturmgeschütz"
+msgstr "Zwillingssturmkanone"
 
 #: po/custom/fromJson.txt:1349
 msgid "Twin Assault Cannon Bunker"
-msgstr "Bunker mit Zwillingssturmgeschütz"
+msgstr "Bunker mit Zwillingssturmkanone"
 
 #: po/custom/fromJson.txt:1350
 msgid "Twin Assault Gun"
@@ -9309,7 +9309,7 @@ msgstr "Verwenden Sie einen LKW, um eine Forschungseinrichtung um ein Modul zu e
 
 #: po/custom/fromJson.txt:1367
 msgid "Uses advanced cannon technology"
-msgstr "Verwendet fortschrittliche Geschütztechnologie"
+msgstr "Verwendet fortschrittliche Kanonentechnologie"
 
 #: po/custom/fromJson.txt:1368
 msgid "Uses advanced mass driver railgun technology"
@@ -9373,7 +9373,7 @@ msgstr "Vengeance Ketten Gauß Scourge-Lenkrakete"
 
 #: po/custom/fromJson.txt:1388
 msgid "Vengeance Tracks Rail Gun"
-msgstr "Vengeance Ketten Magnetgeschütz"
+msgstr "Vengeance Ketten Magnetkanone"
 
 #: po/custom/fromJson.txt:1389
 msgid "Vertical Take Off and Landing Propulsion"
@@ -9417,7 +9417,7 @@ msgstr "VTOL"
 
 #: po/custom/fromJson.txt:1399
 msgid "VTOL Assault Cannon"
-msgstr "VTOL-Sturmgeschütz"
+msgstr "VTOL-Sturmkanone"
 
 #: po/custom/fromJson.txt:1400
 msgid "VTOL Assault Gun"
@@ -9437,7 +9437,7 @@ msgstr "VTOL-Bunker Buster Scorpion VTOL"
 
 #: po/custom/fromJson.txt:1404
 msgid "VTOL Cannon"
-msgstr "VTOL-Geschütz"
+msgstr "VTOL-Kanone"
 
 #: po/custom/fromJson.txt:1406
 msgid "VTOL CB Radar Tower"
@@ -9506,19 +9506,19 @@ msgstr "Schweres VTOL-Maschinengewehr"
 
 #: po/custom/fromJson.txt:1423
 msgid "VTOL Hyper Velocity Cannon"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz"
+msgstr "VTOL-Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:1424
 msgid "VTOL Hyper Velocity Cannon Bug VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Bug VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Bug VTOL"
 
 #: po/custom/fromJson.txt:1425
 msgid "VTOL Hyper Velocity Cannon Mantis VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Mantis VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Mantis VTOL"
 
 #: po/custom/fromJson.txt:1426
 msgid "VTOL Hyper Velocity Cannon Scorpion VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Scorpion VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Scorpion VTOL"
 
 #: po/custom/fromJson.txt:1427
 msgid "VTOL II"
@@ -9554,7 +9554,7 @@ msgstr "VTOL-Miniraketen"
 
 #: po/custom/fromJson.txt:1435
 msgid "VTOL Needle Gun"
-msgstr "VTOL-Nadelgeschütz"
+msgstr "VTOL-Nadelkanone"
 
 #: po/custom/fromJson.txt:1436
 msgid "VTOL Phosphor Bomb Bay"
@@ -9578,7 +9578,7 @@ msgstr "VTOL-Radarturm"
 
 #: po/custom/fromJson.txt:1442
 msgid "VTOL Rail Gun"
-msgstr "VTOL-Magnetgeschütz"
+msgstr "VTOL-Magnetkanone"
 
 # Diese Stationen reparieren und wiederbewaffnen VTOLs, von daher ist Servicestation sehr gut -Kreuvf
 #: po/custom/fromJson.txt:1443
@@ -13091,19 +13091,19 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Einheitenfarbe (MP)"
 
 #~ msgid "VTOL HPV Cannon Bug VTOL"
-#~ msgstr "VTOL-Hochgeschwindigkeitsgeschütz Bug VTOL"
+#~ msgstr "VTOL-Hochgeschwindigkeitskanone Bug VTOL"
 
 #~ msgid "VTOL HPV Cannon Scorpion VTOL"
-#~ msgstr "VTOL-Hochgeschwindigkeitsgeschütz Scorpion VTOL"
+#~ msgstr "VTOL-Hochgeschwindigkeitskanone Scorpion VTOL"
 
 #~ msgid "VTOL HPV Cannon Mantis VTOL"
-#~ msgstr "VTOL-Hochgeschwindigkeitsgeschütz Mantis VTOL"
+#~ msgstr "VTOL-Hochgeschwindigkeitskanone Mantis VTOL"
 
 #~ msgid "Mini-Rocket Artillery Cobra Tracks"
 #~ msgstr "Miniartillerieraketen Cobra Ketten"
 
 #~ msgid "HPV Cannon Python Hover"
-#~ msgstr "Hochgeschwindigkeitsgeschütz Python Hover"
+#~ msgstr "Hochgeschwindigkeitskanone Python Hover"
 
 #~ msgid "CHEATS ARE NOW ENABLED!"
 #~ msgstr "CHEATS SIND JETZT AKTIVIERT!"
@@ -13337,7 +13337,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Aufhängung mit Cyclone FLAK"
 
 #~ msgid "Fire Cannon"
-#~ msgstr "Feuergeschütz"
+#~ msgstr "Feuerkanone"
 
 #~ msgid "Cobra Hover Heavy-Repair"
 #~ msgstr "Cobra Hover Schwerer Reparaturarm"
@@ -13352,13 +13352,13 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Schweres Maschinengewehr Ketten"
 
 #~ msgid "Cobra Hover HC"
-#~ msgstr "Cobra Hover Schweres Geschütz"
+#~ msgstr "Cobra Hover Schwere Kanone"
 
 #~ msgid "Scorpion Lancer Tracks"
 #~ msgstr "Scorpion Lancer Ketten"
 
 #~ msgid "Scorpion Heavy Cannon Tracks"
-#~ msgstr "Scorpion Schweres Geschütz Ketten"
+#~ msgstr "Scorpion Schwere Kanone Ketten"
 
 #~ msgid "Scorpion Lancer VTOL"
 #~ msgstr "Scorpion Lancer VTOL"
@@ -13382,7 +13382,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Lancer Ketten"
 
 #~ msgid "Mantis Heavy Cannon Tracks"
-#~ msgstr "Mantis Schweres Geschütz Ketten"
+#~ msgstr "Mantis Schwere Kanone Ketten"
 
 #~ msgid "Mantis Tank Killer Tracks"
 #~ msgstr "Mantis Tank Killer Tracks"
@@ -13433,7 +13433,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Inferno Halbketten"
 
 #~ msgid "Python HVC Hover"
-#~ msgstr "Python Hochgeschwindigkeitsgeschütz Hover"
+#~ msgstr "Python Hochgeschwindigkeitskanone Hover"
 
 #~ msgid "Python Scourge Tracks"
 #~ msgstr "Python Scourge Ketten"
@@ -13598,7 +13598,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 
 #, fuzzy
 #~ msgid "Increases Bombing damage"
-#~ msgstr "Erhöht Schaden von Geschützen"
+#~ msgstr "Erhöht Schaden von Bomben"
 
 #~ msgid "The ultimate in sensor technology"
 #~ msgstr "Ultimative Sensortechnologie"
@@ -13680,7 +13680,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Anzeige der Energiebalken umgeschaltet"
 
 #~ msgid "Viper Light Cannon Wheels"
-#~ msgstr "Viper Leichtes Geschütz Räder"
+#~ msgstr "Viper Leichte Kanone Räder"
 
 #~ msgid "Viper Flamer Wheels"
 #~ msgstr "Viper Flammenwerfer Räder"
@@ -13689,7 +13689,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Viper Sensor Räder"
 
 #~ msgid "Viper Light Cannon Tracks"
-#~ msgstr "Viper Leichtes Geschütz Halbketten"
+#~ msgstr "Viper Leichte Kanone Halbketten"
 
 #~ msgid "Cobra Heavy Machinegun Half-track"
 #~ msgstr "Cobra Schweres Maschinengewehr Halbketten"
@@ -13698,10 +13698,10 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Mörser Halbketten"
 
 #~ msgid "Cobra Light Cannon Tracks"
-#~ msgstr "Cobra Leichtes Geschütz Ketten"
+#~ msgstr "Cobra Leichte Kanone Ketten"
 
 #~ msgid "Viper Medium Cannon Tracks"
-#~ msgstr "Viper Mittleres Geschütz Ketten"
+#~ msgstr "Viper Mittlere Kanone Ketten"
 
 #~ msgid "Viper Repair Wheels"
 #~ msgstr "Viper Reparaturarm Räder"
@@ -13737,7 +13737,7 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Viper Bunker Buster Räder"
 
 #~ msgid "Cobra Heavy Cannon Tracks"
-#~ msgstr "Cobra Schweres Geschütz Ketten"
+#~ msgstr "Cobra Schwere Kanone Ketten"
 
 #~ msgid "Cobra Sensor Half-track"
 #~ msgstr "Cobra Sensor Halbketten"
@@ -13755,10 +13755,10 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Miniartillerieraketen Halbketten"
 
 #~ msgid "Python Light Cannon Tracks"
-#~ msgstr "Python Leichtes Geschütz Ketten"
+#~ msgstr "Python Leichte Kanone Ketten"
 
 #~ msgid "Python Medium Cannon Tracks"
-#~ msgstr "Python Mittleres Geschütz Ketten"
+#~ msgstr "Python Mittlere Kanone Ketten"
 
 #~ msgid "Python Commander Tracks"
 #~ msgstr "Pyhton Commander Ketten"
@@ -13885,25 +13885,25 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Cobra Ketten Schweres Maschinengewehr"
 
 #~ msgid "Cobra Hover Medium Cannon"
-#~ msgstr "Cobra Hover Mittleres Geschütz"
+#~ msgstr "Cobra Hover Mittlere Kanone"
 
 #~ msgid "Scorpion Hover Medium Cannon"
-#~ msgstr "Scorpion Hover Mittleres Geschütz"
+#~ msgstr "Scorpion Hover Mittlere Kanone"
 
 #~ msgid "Scorpion Tracks Medium Cannon"
-#~ msgstr "Scorpion Ketten Mittleres Geschütz"
+#~ msgstr "Scorpion Ketten Mittlere Kanone"
 
 #~ msgid "Python Hover Medium Cannon"
-#~ msgstr "Python Hover Mittleres Geschütz"
+#~ msgstr "Python Hover Mittlere Kanone"
 
 #~ msgid "Python Hover Heavy Cannon"
-#~ msgstr "Python Hover Schweres Geschütz"
+#~ msgstr "Python Hover Schwere Kanone"
 
 #~ msgid "Python Tracks Heavy Cannon"
-#~ msgstr "Python Ketten Schweres Geschütz"
+#~ msgstr "Python Ketten Schwere Kanone"
 
 #~ msgid "Mantis Tracks Railgun"
-#~ msgstr "Mantis Ketten Magnetgeschütz"
+#~ msgstr "Mantis Ketten Magnetkanone"
 
 #~ msgid "Mantis Tracks Pulse Laser"
 #~ msgstr "Mantis Ketten Pulslaser"
@@ -13918,13 +13918,13 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Vengeance Ketten Tank Killer"
 
 #~ msgid "Tiger Tracks Heavy Cannon"
-#~ msgstr "Tiger Ketten Schweres Geschütz"
+#~ msgstr "Tiger Ketten Schwere Kanone"
 
 #~ msgid "Tiger Tracks Needle Gun"
-#~ msgstr "Tiger Ketten Nadelgeschütz"
+#~ msgstr "Tiger Ketten Nadelkanone"
 
 #~ msgid "Vengeance Tracks Needle Gun"
-#~ msgstr "Vengeance Ketten Nadelgeschütz"
+#~ msgstr "Vengeance Ketten Nadelkanone"
 
 #~ msgid "Scorpion Cluster Bomb VTOL"
 #~ msgstr "Scorpion Streubomben VTOL"
@@ -13936,16 +13936,16 @@ msgstr "Version: %s,%s Erstellt: %s%s"
 #~ msgstr "Bug Lancer VTOL"
 
 #~ msgid "Bug HPV VTOL"
-#~ msgstr "Bug Hochgeschwindigkeitsgeschütz VTOL"
+#~ msgstr "Bug Hochgeschwindigkeitskanone VTOL"
 
 #~ msgid "Scorpion HPV VTOL"
-#~ msgstr "Scorpion Hochgeschwindigkeitsgeschütz VTOL"
+#~ msgstr "Scorpion Hochgeschwindigkeitskanone VTOL"
 
 #~ msgid "Mantis Lancer VTOL"
 #~ msgstr "Mantis Lancer VTOL"
 
 #~ msgid "Mantis HPV VTOL"
-#~ msgstr "Mantis Hochgeschwindigkeitsgeschütz VTOL"
+#~ msgstr "Mantis Hochgeschwindigkeitskanone VTOL"
 
 #~ msgid "Cobra Repair Tracks"
 #~ msgstr "Cobra Reparatur Ketten"


### PR DESCRIPTION
As discussed with Kreuvf all "Geschütze" became "Kanonen" because "Geschütz" is a generic term that includes Cannons, Howitzers, Mortars etc.